### PR TITLE
Add doctor CRUD endpoint

### DIFF
--- a/app/api/routers/doctors.py
+++ b/app/api/routers/doctors.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.api.deps import get_session
+from app.core.container import provide_doctor_service
+from app.domain.schemas.doctor import DoctorCreate, DoctorRead, DoctorUpdate
+
+router = APIRouter(prefix="/doctors", tags=["doctors"])
+
+
+@router.post("/", response_model=DoctorRead, status_code=status.HTTP_201_CREATED)
+async def create_doctor(
+    payload: DoctorCreate, session: AsyncSession = Depends(get_session)
+):
+    service = provide_doctor_service(session)
+    try:
+        return await service.create(payload)
+    except Exception:
+        raise HTTPException(status_code=400, detail="cannot create doctor")
+
+
+@router.get("/{doctor_id}", response_model=DoctorRead)
+async def get_doctor(doctor_id: int, session: AsyncSession = Depends(get_session)):
+    service = provide_doctor_service(session)
+    doctor = await service.get(doctor_id)
+    if not doctor:
+        raise HTTPException(status_code=404, detail="doctor not found")
+    return doctor
+
+
+@router.put("/{doctor_id}", response_model=DoctorRead)
+async def update_doctor(
+    doctor_id: int,
+    payload: DoctorUpdate,
+    session: AsyncSession = Depends(get_session),
+):
+    service = provide_doctor_service(session)
+    doctor = await service.update(doctor_id, payload)
+    if not doctor:
+        raise HTTPException(status_code=404, detail="doctor not found")
+    return doctor
+
+
+@router.delete("/{doctor_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_doctor(doctor_id: int, session: AsyncSession = Depends(get_session)):
+    service = provide_doctor_service(session)
+    await service.delete(doctor_id)

--- a/app/core/container.py
+++ b/app/core/container.py
@@ -1,6 +1,8 @@
 from app.core.config import get_settings
 from app.domain.repositories.user_sqlalchemy import UserRepositorySQLAlchemy
+from app.domain.repositories.doctor_sqlalchemy import DoctorRepositorySQLAlchemy
 from app.domain.services.user_service import UserService
+from app.domain.services.doctor_service import DoctorService
 
 Settings = get_settings
 
@@ -9,3 +11,11 @@ def provide_user_repository(session) -> UserRepositorySQLAlchemy:
 
 def provide_user_service(session) -> UserService:
     return UserService(repo=provide_user_repository(session))
+
+
+def provide_doctor_repository(session) -> DoctorRepositorySQLAlchemy:
+    return DoctorRepositorySQLAlchemy(session=session)
+
+
+def provide_doctor_service(session) -> DoctorService:
+    return DoctorService(repo=provide_doctor_repository(session))

--- a/app/domain/models/doctor.py
+++ b/app/domain/models/doctor.py
@@ -1,0 +1,10 @@
+from sqlalchemy import String
+# noqa: D100
+from sqlalchemy.orm import Mapped, mapped_column
+from app.db.base import Base
+
+
+class Doctor(Base):
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String(255))
+    specialty: Mapped[str] = mapped_column(String(255))

--- a/app/domain/repositories/base.py
+++ b/app/domain/repositories/base.py
@@ -1,5 +1,6 @@
 from typing import Protocol, runtime_checkable, Iterable, Optional
 from app.domain.models.user import User
+from app.domain.models.doctor import Doctor
 
 @runtime_checkable
 class UserRepository(Protocol):
@@ -7,3 +8,17 @@ class UserRepository(Protocol):
     async def get_by_id(self, user_id: int) -> Optional[User]: ...
     async def get_by_email(self, email: str) -> Optional[User]: ...
     async def list(self, *, limit: int = 50, offset: int = 0) -> Iterable[User]: ...
+
+
+@runtime_checkable
+class DoctorRepository(Protocol):
+    async def create(self, *, name: str, specialty: str) -> Doctor: ...
+    async def get_by_id(self, doctor_id: int) -> Optional[Doctor]: ...
+    async def update(
+        self,
+        doctor_id: int,
+        *,
+        name: str,
+        specialty: str,
+    ) -> Optional[Doctor]: ...
+    async def delete(self, doctor_id: int) -> None: ...

--- a/app/domain/repositories/doctor_sqlalchemy.py
+++ b/app/domain/repositories/doctor_sqlalchemy.py
@@ -1,0 +1,51 @@
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.domain.models.doctor import Doctor
+
+
+class DoctorRepositorySQLAlchemy:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(self, *, name: str, specialty: str) -> Doctor:
+        doctor = Doctor(name=name, specialty=specialty)
+        self.session.add(doctor)
+        try:
+            await self.session.commit()
+        except IntegrityError:
+            await self.session.rollback()
+            raise
+        await self.session.refresh(doctor)
+        return doctor
+
+    async def get_by_id(self, doctor_id: int):
+        res = await self.session.execute(select(Doctor).where(Doctor.id == doctor_id))
+        return res.scalar_one_or_none()
+
+    async def update(self, doctor_id: int, *, name: str, specialty: str):
+        res = await self.session.execute(select(Doctor).where(Doctor.id == doctor_id))
+        doctor = res.scalar_one_or_none()
+        if not doctor:
+            return None
+        doctor.name = name
+        doctor.specialty = specialty
+        try:
+            await self.session.commit()
+        except IntegrityError:
+            await self.session.rollback()
+            raise
+        await self.session.refresh(doctor)
+        return doctor
+
+    async def delete(self, doctor_id: int):
+        res = await self.session.execute(select(Doctor).where(Doctor.id == doctor_id))
+        doctor = res.scalar_one_or_none()
+        if not doctor:
+            return
+        await self.session.delete(doctor)
+        try:
+            await self.session.commit()
+        except IntegrityError:
+            await self.session.rollback()
+            raise

--- a/app/domain/schemas/doctor.py
+++ b/app/domain/schemas/doctor.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel
+
+
+class DoctorBase(BaseModel):
+    name: str
+    specialty: str
+
+
+class DoctorCreate(DoctorBase):
+    pass
+
+
+class DoctorUpdate(DoctorBase):
+    pass
+
+
+class DoctorRead(DoctorBase):
+    id: int
+
+    model_config = {
+        "from_attributes": True,
+    }

--- a/app/domain/services/doctor_service.py
+++ b/app/domain/services/doctor_service.py
@@ -1,0 +1,25 @@
+from typing import Optional
+from app.domain.schemas.doctor import DoctorCreate, DoctorRead, DoctorUpdate
+from app.domain.repositories.base import DoctorRepository
+
+
+class DoctorService:
+    def __init__(self, repo: DoctorRepository):
+        self.repo = repo
+
+    async def create(self, payload: DoctorCreate) -> DoctorRead:
+        doctor = await self.repo.create(name=payload.name, specialty=payload.specialty)
+        return DoctorRead.model_validate(doctor)
+
+    async def get(self, doctor_id: int) -> Optional[DoctorRead]:
+        doctor = await self.repo.get_by_id(doctor_id)
+        return DoctorRead.model_validate(doctor) if doctor else None
+
+    async def update(self, doctor_id: int, payload: DoctorUpdate) -> Optional[DoctorRead]:
+        doctor = await self.repo.update(
+            doctor_id, name=payload.name, specialty=payload.specialty
+        )
+        return DoctorRead.model_validate(doctor) if doctor else None
+
+    async def delete(self, doctor_id: int) -> None:
+        await self.repo.delete(doctor_id)

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ load_dotenv()
 from fastapi import FastAPI
 from app.core.config import get_settings
 from app.core.logging import setup_logging
-from app.api.routers import health, users
+from app.api.routers import health, users, doctors
 
 setup_logging()
 settings = get_settings()
@@ -12,3 +12,4 @@ settings = get_settings()
 app = FastAPI(title=settings.APP_NAME, debug=settings.DEBUG)
 app.include_router(health.router)
 app.include_router(users.router)
+app.include_router(doctors.router)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import asyncio
+
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
+
 from app.main import app
 
 @pytest.fixture(scope="session")
@@ -10,5 +12,6 @@ def event_loop():
 
 @pytest.fixture
 async def client():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac


### PR DESCRIPTION
## Summary
- add Doctor model, repository, service, and schemas
- implement /doctors CRUD API and wire into main app
- adjust container and repository interfaces for doctors

## Testing
- `make lint` *(fails: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`: - 'select' -> 'lint.select')*
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6895eef62c60832f83eef6cfab150cfa