### PR TITLE
Fix test client setup for latest httpx

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
 import asyncio
+
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
+
 from app.main import app
+
 
 @pytest.fixture(scope="session")
 def event_loop():
@@ -10,5 +13,6 @@ def event_loop():
 
 @pytest.fixture
 async def client():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac


### PR DESCRIPTION
## Summary
- fix test client fixture to use ASGITransport with httpx>=0.28

## Testing
- `pre-commit run --files tests/conftest.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6895eeb1fe7c832f8d211d3ff406fd39